### PR TITLE
avoid crash if barman alias contains "-"

### DIFF
--- a/barman_exporter_cli.py
+++ b/barman_exporter_cli.py
@@ -38,14 +38,14 @@ class Barman:
             backup = {}
             backup['server'] = server_name
             try:
-                server_name_and_ts, date, size, wal_size = backup_line.split("-")
+                server_name_and_ts, date, size, wal_size = backup_line.rsplit("-",3)
                 backup['date'] = date.strip()
                 backup['size'] = size.split(":")[1].strip()
                 backup['wal_size'] = wal_size.split(":")[1].strip()
                 backup['status'] = "done"
                 backups_done.append(backup)
             except ValueError:
-                server_name_and_ts, status = backup_line.split("-")
+                server_name_and_ts, status = backup_line.rsplit("-",1)
                 backup['status'] = status.lower()
                 backups_failed.append(backup)
 


### PR DESCRIPTION
If alias of barman contains "-" , the split may fail with the error : 

```
server_name_and_ts, date, size, wal_size = backup_line.split("-")
Jul 12 00:24:03 BAKCUP_SERVER barman_exporter.py[3327]: ValueError: too many values to unpack (expected 4)
```