### PR TITLE
Redirect stderr to stdout for version check. Fix issue #9.

### DIFF
--- a/barman_exporter/barman_exporter.py
+++ b/barman_exporter/barman_exporter.py
@@ -33,7 +33,7 @@ class Barman:
         return output
 
     def version(self):
-        version = barman_cli('-v').split()
+        version = barman_cli('-v', _err_to_out=True).split()
         return version[0]
 
     def servers(self):


### PR DESCRIPTION
I fixed the issue #9 . The problem is related to barman version check for barman 2.10+. Not tested on Barman 2.9 version.